### PR TITLE
maint: Switch from `print -P %F{col-nr}` to `m {col-name}`.

### DIFF
--- a/za-bgn-atclone-handler
+++ b/za-bgn-atclone-handler
@@ -42,7 +42,7 @@ if [[ -n "${ICE[gem]}" ]] {
             command gem install -q --no-user-install -i "$dir" "${gems[@]}"
         elif [[ $hook = *atpull-<-> ]]; then
             if (( !OPTS[opt_-q,--quiet] )) {
-                print -P -- "%F{38}bin-gem-node annex: %F{154}Updating the gems...%f"
+                m {pre}bin-gem-node annex: {msg2}Updating the gems...
                 command gem update -q --no-user-install -i "$dir" "${gems[@]}"
             } else {
                 command gem update -q --no-user-install -i "$dir" "${gems[@]}" &> /dev/null
@@ -88,7 +88,7 @@ if [[ -n "${ICE[pip]}" ]] {
         (
             builtin cd -q "$dir" && {
                 if (( !OPTS[opt_-q,--quiet] )) {
-                    print -P -- "%F{38}bin-gem-node annex: %F{154}Updating the pip packages...%f"
+                    m {pre}bin-gem-node annex: {msg2}Updating the pip packages...
                     VIRTUALENV=venv(:A) command venv/bin/pip install --upgrade "${umods[@]}"
                 } else {
                     VIRTUALENV=venv(:A) command venv/bin/pip install -q --upgrade "${umods[@]}"
@@ -133,7 +133,7 @@ if [[ -n "${ICE[node]}" ]] {
         (
             builtin cd -q "$dir" && {
                 if (( !OPTS[opt_-q,--quiet] )) {
-                    print -P -- "%F{38}bin-gem-node annex: %F{154}Updating the node modules...%f"
+                    m {pre}bin-gem-node annex: {msg2}Updating the node modules...
                     command npm --silent update
                 } else {
                     command npm --silent update &> /dev/null
@@ -173,7 +173,7 @@ if (( ${+ICE[sbin]} )) {
                     if (( ${#files} )); then
                         sbin="${files[1]}"
                     else
-                        print -P -- "%F{38}bin-gem-node annex: %F{160}The automatic-empty sbin ice didn't find any executable files%f"
+                        m {pre}bin-gem-node annex: {error}The automatic-empty sbin ice didn\'t find any executable files
                         break
                     fi
                 fi
@@ -200,7 +200,8 @@ if (( ${+ICE[sbin]} )) {
             eval "fnames=( ${srcdst[1]}(Nnon-.) )"
 
             if (( !${#fnames} )) {
-                print -P -- "%F{38}bin-gem-node annex: %F{160}Warning: %F{154}The sbin'' ice (\`%F{219}$sbin%F{154}') didn't match any files%f"
+                m {pre}bin-gem-node annex: {error}Warning: {msg2}The sbin\'\' \
+                    ice \(\`{ice}$sbin{msg2}'\) didn\'t match any files
                 continue
             }
 
@@ -221,7 +222,7 @@ if (( ${+ICE[sbin]} )) {
                             >! "$file.cmd"
                         command chmod +x "$file.cmd"
                 fi
-                
+
                 .za-bgn-bin-or-src-function-body 0 \
                             "$fnam" \
                             "$target_binary" "$dir" "$set_gem_home" \
@@ -236,13 +237,13 @@ if (( ${+ICE[sbin]} )) {
                     (( !OPTS[opt_-q,--quiet] )) && \
                         if [[ -x $target_binary ]]; then
                             if [[ $hook == atclone-<-> || $ZINIT[annex-multi-flag:pull-active] -ge  2 ]] {
-                                print -P -- "%F{38}bin-gem-node annex: %F{154}${${${hook:#*atclone-<->}:+Re-c}:-C}reated the %F{219}$fnam%F{154} shim and set +x on the %F{219}${target_binary:t}%F{154} binary%f"
+                                m {pre}bin-gem-node annex: {msg2}${${${hook:#*atclone-<->}:+Re-c}:-C}reated the {cmd}$fnam{msg2} shim and set +x on the {cmd}${target_binary:t}{msg2} binary
                             }
                         else
-                            print -P -- "%F{38}bin-gem-node annex: %F{154}${${${hook:#*atclone-<->}:+Re-c}:-C}reated the %F{219}$fnam%F{154} shim %F{160}however the %F{219}${target_binary:t}%F{160} binary does not exist or failed to set +x on it%f"
+                            m {pre}bin-gem-node annex: {msg2}${${${hook:#*atclone-<->}:+Re-c}:-C}reated the {cmd}$fnam{msg2} shim {error}however the {cmd}${target_binary:t}{error} binary does not exist or failed to set +x on it
                         fi
                 else
-                    print -P -- "%F{38}bin-gem-node annex: %F{160}Something went wrong creating the %F{219}$fnam%F{160} shim%f"
+                    m {pre}bin-gem-node annex: {error}Something went wrong creating the {cmd}$fnam{error} shim
                 fi
             }
         }
@@ -269,9 +270,9 @@ if [[ -n "${ICE[fbin]}" ]] {
 
         if [[ -x $target_binary ]]; then
             (( !OPTS[opt_-q,--quiet] )) && \
-                print -P -- "%F{38}bin-gem-node annex: %F{154}Set +x on the %F{219}${target_binary:t}%F{154} binary%f"
+                m {pre}bin-gem-node annex: {msg2}Set +x on the {cmd}${target_binary:t}{msg2} binary
         else
-            print -P -- "%F{38}bin-gem-node annex: %F{160}Something went wrong setting +x on the %F{219}${target_binary:t}%F{160} binary%f"
+            m {pre}bin-gem-node annex: {error}Something went wrong setting +x on the {cmd}${target_binary:t}{error} binary
         fi
     }
 }

--- a/za-bgn-atdelete-handler
+++ b/za-bgn-atdelete-handler
@@ -37,7 +37,7 @@ if (( ${+ICE[sbin]} )) {
                     if (( ${#files} )); then
                         sbin="${files[1]}"
                     else
-                        print -P -- "%F{38}bin-gem-node annex: %F{160}The automatic-empty sbin ice didn't find any executable files%f"
+                        m {pre}bin-gem-node annex: {error}The automatic-empty sbin ice didn\'t find any executable files
                         break
                     fi
                 fi
@@ -67,12 +67,12 @@ if (( ${+ICE[sbin]} )) {
                 if [[ -f $file ]]; then
                     command rm -f "$file"
                     if [[ -f $file ]]; then
-                        print -P -- "%F{38}bin-gem-node annex: %F{160}Couldn't remove the %F{220}$fnam%F{160} shim from \$ZPFX/bin (no write access to \$ZPFX/bin?)%f"
+                        m {pre}bin-gem-node annex: {error}Couldn\'t remove the {cmd}$fnam{error} shim from {dir}\$ZPFX/bin{error} \(no write access to {dir}\$ZPFX/bin{error}?\)
                     else
-                        print -P -- "%F{38}bin-gem-node annex: %F{154}Correctly removed the %F{220}$fnam%F{154} shim from \$ZPFX/bin%f" || \
+                        m {pre}bin-gem-node annex: {msg2}Correctly removed the {cmd}$fnam{msg2} shim from {dir}\$ZPFX/bin 
                     fi
                 else
-                    print -P -- "%F{38}bin-gem-node annex: %F{160}The %F{220}$fnam%F{160} shim didn't exist in \$ZPFX/bin (or isn't a regular file)%f"
+                    m {pre}bin-gem-node annex: {error}The {cmd}$fnam{error} shim didn\'t exist in {dir}\$ZPFX/bin{error} (or isn\'t a regular file) 
                 fi
             }
         }

--- a/za-bgn-atload-handler
+++ b/za-bgn-atload-handler
@@ -150,7 +150,9 @@ if (( ${+ICE[fbin]}${+ICE[fsrc]}${+ICE[ferc]} > 0 )) {
                 if (( ${#files} )); then
                     fbin="${files[1]}"
                 else
-                    print -P -- "%F{38}bin-gem-node annex: %F{160}The automatic-empty fbin ice didn't find any executable files for %F{219}$id_as%f"
+                    m {pre}bin-gem-node annex: {error}The automatic-empty \
+                        {ice}fbin{error} ice didn\'t find any executable \
+                            files for {id-as}$id_as
                     break
                 fi
             fi


### PR DESCRIPTION
The `m` function is automatically provided for the moment of loading/installing a plugin and it's the same as `+zinit-message`. With this patch, `bgn` annex will support theming from https://github.com/zdharma-continuum/zinit/pull/445.


<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

`s/print -P --/m …` 
## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
To make messages from `bgn` annex follow `$ZITHEME` themes.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

https://github.com/zdharma-continuum/zinit/pull/445.

## Usage examples <!--- Provide examples of intended usage -->

```zsh
m {pre}bgn-annex:{warn} returned code is {num}1
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
