### PR TITLE
feat: Make any binary name given to sbin'' ice be searched via preceding **/…

### DIFF
--- a/za-bgn-atclone-handler
+++ b/za-bgn-atclone-handler
@@ -158,18 +158,22 @@ if (( ${+ICE[sbin]} )) {
 
         for sbin ( $sbins "" ) {
             integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 \
-                    use_all_null=0 use_err_null=0 use_out_null=0
+                    use_all_null=0 use_err_null=0 use_out_null=0 use_1=0
 
-            if [[ -z $sbin && ${#sbins} -eq 0 ]] {
+            if [[ -z $sbin ]]; then
                 if [[ -f $dir/${id_as:t} ]]; then
                     sbin="$dir/${id_as:t}"
                 elif [[ -n $plugin && -f $dir/$plugin ]]; then
                     sbin="$dir/$plugin"
                 elif [[ -n $url && -f $dir/${url:t} ]]; then
                     sbin="$dir/${url:t}"
+                # Search in tree.
+                elif [[ -f $dir/**/($id_as:t|$plugin)(#qN[1].) ]]; then
+                    sbin=( $dir/**/($id_as:t|$plugin)(Nnon.) )
+                    sbin=$sbin[1]
                 else
                     local -a files
-                    files=( $dir/*(*Nnon:t) )
+                    files=( $dir/**/*(*Nnon:t) )
                     if (( ${#files} )); then
                         sbin="${files[1]}"
                     else
@@ -177,28 +181,31 @@ if (( ${+ICE[sbin]} )) {
                         break
                     fi
                 fi
-            } elif [[ -z $sbin ]] {
-                continue
-            }
+            fi
 
-            srcdst=( ${(@s.->.)sbin} )
+            srcdst=( ${(@s.=>.)${(@s.→.)${(@s.->.)sbin}}} )
             srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
-            [[ ${srcdst[1]} = [gnpcNEO]#g[gnpcNEO]#:* ]] && set_gem_home=1
-            [[ ${srcdst[1]} = [gnpcNEO]#n[gnpcNEO]#:* ]] && set_node_path=1
-            [[ ${srcdst[1]} = [gnpcNEO]#p[gnpcNEO]#:* ]] && set_virtualenv=1
-            [[ ${srcdst[1]} = [gnpcNEO]#c[gnpcNEO]#:* ]] && set_cwd=1
-            [[ ${srcdst[1]} = [gnpcNEO]#N[gnpcNEO]#:* ]] && use_all_null=1
-            [[ ${srcdst[1]} = [gnpcNEO]#E[gnpcNEO]#:* ]] && use_err_null=1
-            [[ ${srcdst[1]} = [gnpcNEO]#O[gnpcNEO]#:* ]] && use_out_null=1
-            srcdst[1]=${srcdst[1]#[a-zA-Z]#:}
+            [[ ${srcdst[1]} = [1gnpcNEO]#g[1gnpcNEO]#:* ]] && set_gem_home=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#n[1gnpcNEO]#:* ]] && set_node_path=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#p[1gnpcNEO]#:* ]] && set_virtualenv=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#c[1gnpcNEO]#:* ]] && set_cwd=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#N[1gnpcNEO]#:* ]] && use_all_null=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#E[1gnpcNEO]#:* ]] && use_err_null=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#O[1gnpcNEO]#:* ]] && use_out_null=1
+            [[ ${srcdst[1]} = [1gnpcNEO]#1[1gnpcNEO]#:* ]] && use_1=1
+            srcdst[1]=${srcdst[1]#[a-zA-Z0-9]#:}
 
             # Substitute the standard keywords and param''-s
             @zinit-substitute 'srcdst[1]' 'srcdst[2]'
 
             local -a fnames
             local fname
-            eval "fnames=( ${srcdst[1]}(Nnon-.) )"
-
+            if [[ $srcdst[1] != /* ]]; then
+                # Search tree and sort from ./
+                eval "fnames=( **/${srcdst[1]}(Nnon-.) )"
+            else
+                eval "fnames=( ${srcdst[1]}(Nnon-.) )"
+            fi
             if (( !${#fnames} )) {
                 print -P -- "%F{38}bin-gem-node annex: %F{160}Warning: %F{154}The sbin'' ice (\`%F{219}$sbin%F{154}') didn't match any files%f"
                 continue
@@ -243,6 +250,14 @@ if (( ${+ICE[sbin]} )) {
                         fi
                 else
                     print -P -- "%F{38}bin-gem-node annex: %F{160}Something went wrong creating the %F{219}$fnam%F{160} shim%f"
+                fi
+                if ((use_1)); then
+                    (($#fnames-1)) && \
+                        +zinit-message {pre}bin-gem-node annex: {warn}Skipped \
+                            {num}$(($#fnames-1)){warn} files that match the \
+                            {ice}sbin\'\'{warn} ice \({obj}${(j:, :)fnames[2,8]}\
+${${$(($#fnames>8)):#0}:+,{b}{note}$(($#fnames-8)) more\{…\}}{warn}\), because of {flag}1:…{warn} flag given
+                    break
                 fi
             }
         }

--- a/za-bgn-atclone-handler
+++ b/za-bgn-atclone-handler
@@ -150,13 +150,14 @@ if (( ${+ICE[sbin]} )) {
     local -a sbins srcdst
     sbins=( ${(s.;.)ICE[sbin]} )
 
+    (( !$#sbins )) && sbins+=("")
     local sbin
 
     (
         # CD for the globbing through eval
         builtin cd -q "$dir" || return
 
-        for sbin ( $sbins "" ) {
+        for sbin ( $sbins  ) {
             integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 \
                     use_all_null=0 use_err_null=0 use_out_null=0 use_1=0
 
@@ -183,6 +184,7 @@ if (( ${+ICE[sbin]} )) {
                 fi
             fi
 
+            # Allow multiple separators, =>,->,→
             srcdst=( ${(@s.=>.)${(@s.→.)${(@s.->.)sbin}}} )
             srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
             [[ ${srcdst[1]} = [1gnpcNEO]#g[1gnpcNEO]#:* ]] && set_gem_home=1
@@ -227,6 +229,7 @@ if (( ${+ICE[sbin]} )) {
                         builtin print -r -- "$REPLY" \
                             >! "$file.cmd"
                         command chmod +x "$file.cmd"
+                        continue
                 fi
                 
                 .za-bgn-bin-or-src-function-body 0 \


### PR DESCRIPTION
This allows to simply leave the ice empty, to find **/$id_as or **/$plugin, or specify a binary name without need to give it a **/… glob, because it is boring to do, as someone once noted (didn't find the post).

Second change is a new "1:…" option to limit the number of shims created to only 1. So, e.g.: `sbin'1:exa*'` to have only first, shortest path exa found be given a shim.


<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh

```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
