### PR TITLE
fix: Fix double shim creating when non-empty sbin'' ice.

### DIFF
--- a/za-bgn-atclone-handler
+++ b/za-bgn-atclone-handler
@@ -150,13 +150,14 @@ if (( ${+ICE[sbin]} )) {
     local -a sbins srcdst
     sbins=( ${(s.;.)ICE[sbin]} )
 
+    (( !$#sbins )) && sbins+=("")
     local sbin
 
     (
         # CD for the globbing through eval
         builtin cd -q "$dir" || return
 
-        for sbin ( $sbins "" ) {
+        for sbin ( $sbins  ) {
             integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 \
                     use_all_null=0 use_err_null=0 use_out_null=0
 
@@ -220,6 +221,7 @@ if (( ${+ICE[sbin]} )) {
                         builtin print -r -- "$REPLY" \
                             >! "$file.cmd"
                         command chmod +x "$file.cmd"
+                        continue
                 fi
                 
                 .za-bgn-bin-or-src-function-body 0 \


### PR DESCRIPTION
Currently, e.g. following command:

```zsh
zi sbin'dstask*->tsk' bpick'dstask-linux-amd*' ghapi from'gh-r' for dstask
```

Will create two shims, `tsk` and 'dstask-linux-amd64'.

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

An unconditional iteration over `""` shim with:

```zsh
for sbin ( $sbins "" )
```

has been changed to conditional iteration with:

```zsh
(( !$#sbins )) && sbins+=("")
```


## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

To create shims correctly without extra one.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

#21 

## Usage examples <!--- Provide examples of intended usage -->

No `unscope` annex example:

```zsh
zi sbin'dstask*->tsk' bpick'dstask-linux-amd*' from'gh-r' for naggie/dstask
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
