### PR TITLE
fix: fmod vars & whitespace trim pattern

### DIFF
--- a/za-bgn-atload-handler
+++ b/za-bgn-atload-handler
@@ -1,226 +1,162 @@
 # Copyright (c) 2019-2020 Sebastian Gniazdowski
+# Copyright (c) 2020-2023 Zdharma-continuum
 # License MIT
 
-za-bgn-atload-handler() {
-
-emulate -RL zsh
-setopt extendedglob warncreateglobal typesetsilent noshortloops
-
-if [[ "$1" = plugin ]] {
-    local type="$1" user="$2" plugin="$3" id_as="$4" dir="${5#%}" hook="$6"
-} else {
-    local type="$1" url="$2" id_as="$3" dir="${4#%}" hook="$5"
-}
-
-local nl=$'\n'
-
-#
-# gem'' ice
-#
-
-if [[ -n "${ICE[gem]}" ]] {
-    local -a gems srcdst tmpsdst
-    gems=( "${(s.;.)ICE[gem]}" )
-
-    local gem
-    integer add_fbin
-
-    for gem ( $gems ) {
-        srcdst=( ${(@s.->.)gem} )
-        tmpsdst=( ${(@s.<-.)srcdst[1]} )
-        if (( ${#tmpsdst} > 1 )); then
-            srcdst=( "${tmpsdst[1]}" "${tmpsdst[2]}" "${srcdst[2]:-${tmpdist[2]#\!}}" )
-        else
-            srcdst=( "${tmpsdst[1]#\!}" "${tmpsdst[1]}" "${srcdst[2]:-${srcdst[1]#\!}}" )
-        fi
-        srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
-        [[ ${srcdst[2]} = \!* ]] && add_fbin=1 || add_fbin=0
-        srcdst[2]=${srcdst[2]#\!}
-
-        # Substitute the standard keywords and param''-s
-        @zinit-substitute 'srcdst[1]' 'srcdst[2]' 'srcdst[3]'
-
-        if (( add_fbin )); then
-            local target_binary="g:$dir/bin/${srcdst[1]}"
-            ICE[fbin]+="${ICE[fbin]:+;}$target_binary -> ${srcdst[3]}"
-        fi
-    }
-}
-
-#
-# node'' ice
-#
-
-if [[ -n "${ICE[node]}" ]] {
-    local -a nodes srcdst tmpsdst
-    nodes=( "${(s.;.)ICE[node]}" )
-
-    local node
-    integer add_fbin
-
-    for node ( $nodes ) {
-        srcdst=( ${(@s.->.)node} )
-        tmpsdst=( ${(@s.<-.)srcdst[1]} )
-        if (( ${#tmpsdst} > 1 )); then
-            srcdst=( "${tmpsdst[1]}" "${tmpsdst[2]}" "${srcdst[2]:-${tmpdist[2]#\!}}" )
-        else
-            srcdst=( "${tmpsdst[1]#\!}" "${tmpsdst[1]}" "${srcdst[2]:-${srcdst[1]#\!}}" )
-        fi
-        srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
-        [[ ${srcdst[2]} = \!* ]] && add_fbin=1 || add_fbin=0
-        srcdst[2]=${srcdst[2]#\!}
-
-        # Substitute the standard keywords and param''-s
-        @zinit-substitute 'srcdst[1]' 'srcdst[2]' 'srcdst[3]'
-
-        if (( add_fbin )); then
-            local target_binary="n:$dir/node_modules/.bin/${srcdst[1]}"
-            ICE[fbin]+="${ICE[fbin]:+;}$target_binary -> ${srcdst[3]}"
-        fi
-    }
-}
-
-#
-# pip'' ice
-#
-
-if [[ -n "${ICE[pip]}" ]] {
-    local -a pips srcdst tmpsdst
-    pips=( "${(s.;.)ICE[pip]}" )
-
-    local pip
-    integer add_fbin
-
-    for pip ( $pips ) {
-        srcdst=( ${(@s.->.)pip} )
-        tmpsdst=( ${(@s.<-.)srcdst[1]} )
-        if (( ${#tmpsdst} > 1 )); then
-            srcdst=( "${tmpsdst[1]}" "${tmpsdst[2]}" "${srcdst[2]:-${tmpdist[2]#\!}}" )
-        else
-            srcdst=( "${tmpsdst[1]#\!}" "${tmpsdst[1]}" "${srcdst[2]:-${srcdst[1]#\!}}" )
-        fi
-        srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
-        [[ ${srcdst[2]} = \!* ]] && add_fbin=1 || add_fbin=0
-        srcdst[2]=${srcdst[2]#\!}
-
-        # Substitute the standard keywords and param''-s
-        @zinit-substitute 'srcdst[1]' 'srcdst[2]' 'srcdst[3]'
-
-        if (( add_fbin )); then
-            local target_binary="p:$dir/venv/bin/${srcdst[1]}"
-            ICE[fbin]+="${ICE[fbin]:+;}$target_binary -> ${srcdst[3]}"
-        fi
-    }
-}
-
-#
-# fbin'' ice – also inheriting any exclamation-mark gems
-# or node modules
-#
-
-if (( ${+ICE[fbin]}${+ICE[fsrc]}${+ICE[ferc]} > 0 )) {
-    local -a fbins fsrcs fercs srcdst
-    fbins=( ${(s.;.)ICE[fbin]} )
-    fsrcs=( ${(s.;.)ICE[fsrc]} )
-    fercs=( ${(s.;.)ICE[ferc]} )
-
-    local fbin
-    integer run_type=0
-
-    for fbin ( $fbins "" "<sep1>" $fsrcs "" "<sep2>" $fercs "" ) {
-        integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 \
-                use_all_null=0 use_err_null=0 use_out_null=0
-
-        [[ "$fbin" = "<sep1>" ]] && { run_type=1; continue; }
-        [[ "$fbin" = "<sep2>" ]] && { run_type=2; continue; }
-
-        if [[ ( ${+ICE[fbin]} -eq 1 && run_type -eq 0 && -z $fbin && ${#fbins} -eq 0 ) || \
-            ( ${+ICE[fsrc]} -eq 1 && run_type -eq 1 && -z $fbin && ${#fsrcs} -eq 0 ) || \
-            ( ${+ICE[ferc]} -eq 1 && run_type -eq 2 && -z $fbin && ${#fercs} -eq 0 )
-        ]]; then
-            if [[ -f $dir/${id_as:t} ]]; then
-                fbin="$dir/${id_as:t}"
-            elif [[ -n $plugin && -f $dir/$plugin ]]; then
-                fbin="$dir/$plugin"
-            elif [[ -n $url && -f $dir/${url:t} ]]; then
-                fbin="$dir/${url:t}"
+za-bgn-atload-handler () {
+    emulate -RL zsh
+    setopt extendedglob warncreateglobal typesetsilent noshortloops
+    if [[ "$1" = plugin ]]
+    then
+        local type="$1" user="$2" plugin="$3" id_as="$4" dir="${5#%}" hook="$6" 
+    else
+        local type="$1" url="$2" id_as="$3" dir="${4#%}" hook="$5" 
+    fi
+    local nl=$'\n' trim_whitespace='((#s)[[:space:]]##|[[:space:]]##(#e))' 
+    if [[ -n "${ICE[gem]}" ]]; then
+        local -a gems srcdst tmpsdst
+        gems=("${(s.;.)ICE[gem]}") 
+        local gem
+        integer add_fbin
+        for gem in $gems; do
+            srcdst=(${(@s.->.)gem}) 
+            tmpsdst=(${(@s.<-.)srcdst[1]}) 
+            if (( ${#tmpsdst} > 1 )); then
+                srcdst=("${tmpsdst[1]}" "${tmpsdst[2]}" "${srcdst[2]:-${tmpdist[2]#\!}}") 
             else
-                local -a files
-                files=( $dir/*(*Non:t) )
-                if (( ${#files} )); then
-                    fbin="${files[1]}"
-                else
-                    print -P -- "%F{38}bin-gem-node annex: %F{160}The automatic-empty fbin ice didn't find any executable files for %F{219}$id_as%f"
-                    break
-                fi
+                srcdst=("${tmpsdst[1]#\!}" "${tmpsdst[1]}" "${srcdst[2]:-${srcdst[1]#\!}}") 
             fi
-        elif [[ -z $fbin ]]; then
-            continue
-        fi
-
-        srcdst=( ${(@s.->.)fbin} )
-        srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
-        [[ ${srcdst[1]} = [gnpcNEO]#g[gnpcNEO]#:* ]] && set_gem_home=1
-        [[ ${srcdst[1]} = [gnpcNEO]#n[gnpcNEO]#:* ]] && set_node_path=1
-        [[ ${srcdst[1]} = [gnpcNEO]#p[gnpcNEO]#:* ]] && set_virtualenv=1
-        [[ ${srcdst[1]} = [gnpcNEO]#c[gnpcNEO]#:* ]] && set_cwd=1
-        [[ ${srcdst[1]} = [gnpcNEO]#N[gnpcNEO]#:* ]] && use_all_null=1
-        [[ ${srcdst[1]} = [gnpcNEO]#E[gnpcNEO]#:* ]] && use_err_null=1
-        [[ ${srcdst[1]} = [gnpcNEO]#O[gnpcNEO]#:* ]] && use_out_null=1
-        srcdst[1]=${srcdst[1]#[a-zA-Z]#:}
-        
-        # Substitute the standard keywords and param''-s
-        @zinit-substitute 'srcdst[1]' 'srcdst[2]'
-
-        local target_binary="${${(M)srcdst[1]:#/*}:-$dir/${srcdst[1]}}"
-
-        .za-bgn-bin-or-src-function-body "$run_type" \
-                       "${srcdst[2]:-${srcdst[1]:t}}" \
-                       "$target_binary" "$dir" "$set_gem_home" \
-                       "$set_node_path" "$set_virtualenv" "$set_cwd" "$use_all_null" \
-                       "$use_err_null" "$use_out_null"
-        eval "$REPLY"
-    }
-}
-
-#
-# fmod'' ice
-#
-
-if [[ -n "${ICE[fmod]}" ]] {
-    local -a fmods srcdst
-    fmods=( "${(s.;.)ICE[fmod]}" )
-
-    local fmod
-
-    for fmod ( $fmods ) {
-        integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 \
-                use_all_null=0 use_err_null=0 use_out_null=0
-
-        srcdst=( ${(@s.->.)fmod} )
-        srcdst=( "${srcdst[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" )
-        [[ ${srcdst[1]} = [gnpcNEO]#g[gnpcNEO]#:* ]] && set_gem_home=1
-        [[ ${srcdst[1]} = [gnpcNEO]#n[gnpcNEO]#:* ]] && set_node_path=1
-        [[ ${srcdst[1]} = [gnpcNEO]#p[gnpcNEO]#:* ]] && set_virtualenv=1
-        [[ ${srcdst[1]} = [gnpcNEO]#c[gnpcNEO]#:* ]] && set_cwd=1
-        [[ ${srcdst[1]} = [gnpcNEO]#N[gnpcNEO]#:* ]] && use_all_null=1
-        [[ ${srcdst[1]} = [gnpcNEO]#E[gnpcNEO]#:* ]] && use_err_null=1
-        [[ ${srcdst[1]} = [gnpcNEO]#O[gnpcNEO]#:* ]] && use_out_null=1
-        srcdst[1]=${srcdst[1]#[a-zA-Z]#:}
-        
-        # Substitute the standard keywords and param''-s
-        @zinit-substitute 'srcdst[1]' 'srcdst[2]'
-
-        local target_function="${srcdst[1]}"
-
-        .za-bgn-mod-function-body "${srcdst[2]:-${srcdst[1]}}" \
-                       "$target_function" "$dir" "$set_gem_home" \
-                       "$set_node_path" "$set_virtualenv" "$set_cwd" "$use_all_null" \
-                       "$use_err_null" "$use_out_null"
-        eval "$REPLY"
-    }
-}
-
+            srcdst=("${srcdst[@]//${~trim_whitespace}/}") 
+            [[ ${srcdst[2]} = \!* ]] && add_fbin=1  || add_fbin=0 
+            srcdst[2]=${srcdst[2]#\!} 
+            @zinit-substitute 'srcdst[1]' 'srcdst[2]' 'srcdst[3]'
+            if (( add_fbin )); then
+                local target_binary="g:$dir/bin/${srcdst[1]}" 
+                ICE[fbin]+="${ICE[fbin]:+;}$target_binary -> ${srcdst[3]}" 
+            fi
+        done
+    fi
+    if [[ -n "${ICE[node]}" ]]; then
+        local -a nodes srcdst tmpsdst
+        nodes=("${(s.;.)ICE[node]}") 
+        local node
+        integer add_fbin
+        for node in $nodes; do
+            srcdst=(${(@s.->.)node}) 
+            tmpsdst=(${(@s.<-.)srcdst[1]}) 
+            if (( ${#tmpsdst} > 1 )); then
+                srcdst=("${tmpsdst[1]}" "${tmpsdst[2]}" "${srcdst[2]:-${tmpdist[2]#\!}}") 
+            else
+                srcdst=("${tmpsdst[1]#\!}" "${tmpsdst[1]}" "${srcdst[2]:-${srcdst[1]#\!}}") 
+            fi
+            srcdst=("${srcdst[@]//${~trim_whitespace}/}") 
+            [[ ${srcdst[2]} = \!* ]] && add_fbin=1  || add_fbin=0 
+            srcdst[2]=${srcdst[2]#\!} 
+            @zinit-substitute 'srcdst[1]' 'srcdst[2]' 'srcdst[3]'
+            if (( add_fbin )); then
+                local target_binary="n:$dir/node_modules/.bin/${srcdst[1]}" 
+                ICE[fbin]+="${ICE[fbin]:+;}$target_binary -> ${srcdst[3]}" 
+            fi
+        done
+    fi
+    if [[ -n "${ICE[pip]}" ]]; then
+        local -a pips srcdst tmpsdst
+        pips=("${(s.;.)ICE[pip]}") 
+        local pip
+        integer add_fbin=0 
+        for pip in $pips; do
+            srcdst=(${(@s.->.)pip}) 
+            tmpsdst=(${(@s.<-.)srcdst[1]}) 
+            if (( ${#tmpsdst} > 1 )); then
+                srcdst=("${tmpsdst[1]}" "${tmpsdst[2]}" "${srcdst[2]:-${tmpdist[2]#\!}}") 
+            else
+                srcdst=("${tmpsdst[1]#\!}" "${tmpsdst[1]}" "${srcdst[2]:-${srcdst[1]#\!}}") 
+            fi
+            srcdst=("${srcdst[@]//${~trim_whitespace}/}") 
+            if [[ ${srcdst[2]} = \!* ]]; then
+                add_fbin=1 
+            fi
+            srcdst[2]=${srcdst[2]#\!} 
+            @zinit-substitute 'srcdst[1]' 'srcdst[2]' 'srcdst[3]'
+            if (( add_fbin )); then
+                local target_binary="p:$dir/venv/bin/${srcdst[1]}" 
+                ICE[fbin]+="${ICE[fbin]:+;}$target_binary -> ${srcdst[3]}" 
+            fi
+        done
+    fi
+    if (( ${+ICE[fbin]}${+ICE[fsrc]}${+ICE[ferc]} > 0 )); then
+        local -a fbins fsrcs fercs srcdst
+        fbins=(${(s.;.)ICE[fbin]}) 
+        fsrcs=(${(s.;.)ICE[fsrc]}) 
+        fercs=(${(s.;.)ICE[ferc]}) 
+        local fbin
+        integer run_type=0 
+        for fbin in $fbins "" "<sep1>" $fsrcs "" "<sep2>" $fercs ""; do
+            integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 use_all_null=0 use_err_null=0 use_out_null=0 
+            [[ "$fbin" = "<sep1>" ]] && {
+                run_type=1 
+                continue
+            }
+            [[ "$fbin" = "<sep2>" ]] && {
+                run_type=2 
+                continue
+            }
+            if [[ ( ${+ICE[fbin]} -eq 1 && run_type -eq 0 && -z $fbin && ${#fbins} -eq 0 ) || ( ${+ICE[fsrc]} -eq 1 && run_type -eq 1 && -z $fbin && ${#fsrcs} -eq 0 ) || ( ${+ICE[ferc]} -eq 1 && run_type -eq 2 && -z $fbin && ${#fercs} -eq 0 ) ]]; then
+                if [[ -f $dir/${id_as:t} ]]; then
+                    fbin="$dir/${id_as:t}" 
+                elif [[ -n $plugin && -f $dir/$plugin ]]; then
+                    fbin="$dir/$plugin" 
+                elif [[ -n $url && -f $dir/${url:t} ]]; then
+                    fbin="$dir/${url:t}" 
+                else
+                    local -a files
+                    files=($dir/*(*Non:t)) 
+                    if (( ${#files} )); then
+                        fbin="${files[1]}" 
+                    else
+                        print -P -- "%F{38}bin-gem-node annex: %F{160}The automatic-empty fbin ice didn't find any executable files for %F{219}$id_as%f"
+                        break
+                    fi
+                fi
+            elif [[ -z $fbin ]]; then
+                continue
+            fi
+            srcdst=(${(@s.->.)fbin}) 
+            srcdst=("${srcdst[@]//${~trim_whitespace}/}") 
+            [[ ${srcdst[1]} = [gnpcNEO]#g[gnpcNEO]#:* ]] && set_gem_home=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#n[gnpcNEO]#:* ]] && set_node_path=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#p[gnpcNEO]#:* ]] && set_virtualenv=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#c[gnpcNEO]#:* ]] && set_cwd=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#N[gnpcNEO]#:* ]] && use_all_null=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#E[gnpcNEO]#:* ]] && use_err_null=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#O[gnpcNEO]#:* ]] && use_out_null=1 
+            srcdst[1]=${srcdst[1]#[a-zA-Z]#:} 
+            @zinit-substitute 'srcdst[1]' 'srcdst[2]'
+            local target_binary="${${(M)srcdst[1]:#/*}:-$dir/${srcdst[1]}}" 
+            .za-bgn-bin-or-src-function-body "$run_type" "${srcdst[2]:-${srcdst[1]:t}}" "$target_binary" "$dir" "$set_gem_home" "$set_node_path" "$set_virtualenv" "$set_cwd" "$use_all_null" "$use_err_null" "$use_out_null"
+            eval "$REPLY"
+        done
+    fi
+    if [[ -n "${ICE[fmod]}" ]]; then
+        local -a fmods srcdst
+        fmods=("${(s.;.)ICE[fmod]}") 
+        local fmod
+        for fmod in $fmods; do
+            integer use_out_null=0 set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 use_all_null=0 use_err_null=0 
+            srcdst=(${(@s.->.)fmod}) 
+            srcdst=("${srcdst[@]//${~trim_whitespace}/}") 
+            [[ ${srcdst[1]} = [gnpcNEO]#g[gnpcNEO]#:* ]] && set_gem_home=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#n[gnpcNEO]#:* ]] && set_node_path=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#p[gnpcNEO]#:* ]] && set_virtualenv=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#c[gnpcNEO]#:* ]] && set_cwd=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#N[gnpcNEO]#:* ]] && use_all_null=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#E[gnpcNEO]#:* ]] && use_err_null=1 
+            [[ ${srcdst[1]} = [gnpcNEO]#O[gnpcNEO]#:* ]] && use_out_null=1 
+            srcdst[1]=${srcdst[1]#[a-zA-Z]#:} 
+            @zinit-substitute 'srcdst[1]' 'srcdst[2]'; local target_function="${srcdst[1]}" 
+            .za-bgn-mod-function-body "${srcdst[2]:-${srcdst[1]}}" "$target_function" "$dir" "$set_gem_home" "$set_node_path" "$set_virtualenv" "$set_cwd" "$use_all_null" "$use_err_null" "$use_out_null"
+            eval "$REPLY"
+        done
+    fi
 }
 
 # vim:ft=zsh:sw=4:sts=4:et


### PR DESCRIPTION
## Description

- use string pattern and move whitespace trim as variable
- make fmod variables local to remove warning messages

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.