### PR TITLE
Added modifier `!` for ICE `sbin` to speed up execution of shims

### DIFF
--- a/za-bgn-atclone-handler
+++ b/za-bgn-atclone-handler
@@ -151,15 +151,24 @@ if (( ${+ICE[sbin]} )) {
     sbins=( ${(s.;.)ICE[sbin]} )
 
     (( !$#sbins )) && sbins+=("")
-    local sbin
+    local sbin norcs_flag
 
     (
         # CD for the globbing through eval
         builtin cd -q "$dir" || return
 
-        for sbin ( $sbins  ) {
+        for sbin ( $sbins ) {
             integer set_gem_home=0 set_node_path=0 set_virtualenv=0 set_cwd=0 \
                     use_all_null=0 use_err_null=0 use_out_null=0 use_1=0
+            sbin_norcs=  # Default is shell with zshrc; norcs flag is left empty
+            split_args=  # env requires options `-S` to split arguments
+
+            # Detect '!' at the beginning of sbin
+            if [[ $sbin == "!"* ]]; then
+                sbin_norcs=" -fd" # set NORCS flag; it avoids loading zshenv and zshrc files for a faster execution
+                split_args=" -S" # prompt env to split arguments; check `man env`
+                sbin=${sbin#\!}  # Remove the '!' from the sbin string
+            fi
 
             if [[ -z $sbin ]]; then
                 if [[ -f $dir/${id_as:t} ]]; then
@@ -238,7 +247,7 @@ if (( ${+ICE[sbin]} )) {
                             "$set_node_path" "$set_virtualenv" "$set_cwd" "$use_all_null" \
                             "$use_err_null" "$use_out_null"
 
-                builtin print -r -- "#!/usr/bin/env zsh$nl$nl$REPLY$nl$nl$fnam \"\$@\"" \
+                builtin print -r -- "#!/usr/bin/env$split_args zsh$sbin_norcs$nl$nl$REPLY$nl$nl$fnam \"\$@\"" \
                     >! "$file"
                 command chmod +x "$file" "$target_binary"
 

--- a/za-bgn-atclone-handler
+++ b/za-bgn-atclone-handler
@@ -151,7 +151,7 @@ if (( ${+ICE[sbin]} )) {
     sbins=( ${(s.;.)ICE[sbin]} )
 
     (( !$#sbins )) && sbins+=("")
-    local sbin norcs_flag
+    local sbin sbin_norcs split_args
 
     (
         # CD for the globbing through eval


### PR DESCRIPTION
This pull request is to solve a problem I encountered where many of my binaries were taking an excessive time to start (~150-200ms). The delay was quite noticeable when e.g. scrolling through files and visualizing them with `bat` utility. Something felt slow and unresponsive. The reason was that the shim reloaded `zshenv` and `zshrc` files, despite the fact we are calling them already from the command line. So, I added and documented an ICE modifier  `!` for `sbin` that creates a shim with NO RCS option. Below are the detailed modifications:

- Added modifier `!` for ICE `sbin` -> it creates a shim with a NO RCS shell `#!/usr/bin/env -S zsh -fd`. It can save 150 ms to execute the shim, which otherwise are needed to parse the configuration files.
- Documented the new feature in the README.md
- Added instructions when to use `sbin` and when to prefer `lbin`